### PR TITLE
Fixed JSONParse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,11 +163,11 @@ module.exports.get = (function () {
                 return done(new Error('status code: ' + res.statusCode));
             }
 
-            try {
-                movie = JSON.parse(body);
-            } catch (e) {
-                return done(e);
-            }
+            //try {
+                movie = body;
+            //} catch (e) {
+              //return done(e);
+            //}
 
             // The movie being searched for could not be found.
             if (movie.Response === 'False') {


### PR DESCRIPTION
I was getting an error like `Unexpected token o`. Commenting out the json.parse fixed this since the requested website is already a JSON, there is no need to parse it. 