### PR TITLE
added support for Metacritic and Awards properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,10 @@ module.exports.get = (function () {
                     votes: movie.imdbVotes ? formatVotes(movie.imdbVotes) : null
                 },
 
+                metacritic: movie.Metascore ? +movie.Metascore : null,
+
+                awards: movie.Awards ? movie.Awards : "",
+
                 type: movie.Type
             });
         });


### PR DESCRIPTION
I added support for Metacritic and Awards properties to the get() method's returned movie object.  They are mapped to the metacritic and awards properties (lowercased) for consistency with the other properties.