### PR TITLE
Add Rotten Tomatoes rating option to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ is empty. The array will contain objects of the following:
 }
 ```
 
-### omdb.get(show, [fullPlot], callback)
+### omdb.get(show, [options], callback)
 Run a single movie request on the API.
 
 `show` is assumed to be one of the following, respectively:
@@ -95,6 +95,7 @@ Run a single movie request on the API.
 3. An object with *both* a `title` and a `year` property.
 
     `{ title: 'Saw', year: 2004 }`
+
 4. An IMDb ID string.
 
     `'tt0387564'`
@@ -102,8 +103,11 @@ Run a single movie request on the API.
 
     `'Saw'`
 
-`fullPlot` is an optional argument that if set to `true`, will attempt to
-request the extended version of the movie's plot.
+Additionally, `options` object can be passed with the following parameters:
+- `fullPlot` is an optional argument that if set to `true`, will attempt to request the extended version of the movie's plot.
+- `tomatoes` is an optional argument that if set to `true`, will attempt to request the Rotten Tomatoes rating info.
+
+Backwards compatibility is ensured so that if `options` is not an object but is non-empty, assume `fullPlot: true`.
 
 `callback` returns an object of the movie's information. If no movies are
 found, it will return `null`.

--- a/index.js
+++ b/index.js
@@ -129,17 +129,27 @@ module.exports.get = (function () {
         return +votes.match(/\d/g).join('');
     };
 
-    return function (show, fullPlot, done) {
+    return function (show, options, done) {
         var query = {};
 
         // If the third argument is omitted, treat the second argument as the
         // callback.
         if (!done) {
-            done = fullPlot;
-            fullPlot = false;
+            done = options;
+            options = {};
+
+        // If options is given, but is not an object, assume fullPlot: true
+        // for backwards compatibility
+        } else if (typeof options != "object" && options) {
+            options = { fullPlot: true };
         }
 
-        query.plot = fullPlot ? 'full' : 'short';
+        query.plot = options.fullPlot ? 'full' : 'short';
+
+        // Include Rotten Tomatoes rating, if requested
+        if (options.tomatoes) {
+            query.tomatoes = true;
+        }
 
         // Select query based on explicit IMDB ID, explicit title, title & year,
         // IMDB ID and title, respectively.
@@ -224,6 +234,20 @@ module.exports.get = (function () {
                     // Convert votes from a US formatted string of a number to
                     // a JavaScript Number.
                     votes: movie.imdbVotes ? formatVotes(movie.imdbVotes) : null
+                },
+
+                // Determine tomatoRatings existance by the presense of tomatoMeter
+                tomato: !movie.tomatoMeter ? null : {
+                    // Convert numeric values to numeric form
+                    meter: +movie.tomatoMeter,
+                    image: movie.tomatoImage,
+                    rating: +movie.tomatoRating,
+                    reviews: +movie.tomatoReviews,
+                    fresh: +movie.tomatoFresh,
+                    consensus: movie.tomatoConsensus,
+                    userMeter: +movie.tomatoUserMeter,
+                    userRating: +movie.tomatoUserRating,
+                    userReviews: +movie.tomatoUserReviews
                 },
 
                 metacritic: movie.Metascore ? +movie.Metascore : null,


### PR DESCRIPTION
The API has an option to include possible Rotten Tomatoes rating for the movie. This change adds this option to the module.

In order to keep the query options and response options in different arguments for the `.get` function, convert `fullPlot` to an `options` object, while preserving backwards compatibility.