### PR TITLE
Added DVD and Box Office Information to OMDB API

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,6 +244,11 @@ module.exports.get = function (show, options, done) {
 
             // Cast the API's release date as a native JavaScript Date type.
             released: movie.Released ? new Date(movie.Released) : null,
+	
+	    //Added DVD and Box Office Information to returned object
+	    dvd: movie.DVD ? new Date(movie.DVD) : null,
+	    boxOffice: movie.BoxOffice ? +movie.BoxOffice : null,
+
 
             // Return runtime as minutes casted as a Number instead of an
             // arbitrary string.


### PR DESCRIPTION
The DVD and BoxOffice Information that was getting returned from the OMDB api was getting ignored in the output object.
The Two have been added as you can see in the diff:
```
+	    //Added DVD and Box Office Information to returned object
+	    dvd: movie.DVD ? new Date(movie.DVD) : null,
+	    boxOffice: movie.BoxOffice ? +movie.BoxOffice : null
```

Kindly review the same.